### PR TITLE
use 102400 to instead of max_buffered_bytes's default value 1

### DIFF
--- a/templates/kafka.toml.tmpl
+++ b/templates/kafka.toml.tmpl
@@ -33,6 +33,7 @@ topic_variable = "Fields[kafka_topic]"
 addrs = {{.KafkaAddrs}}
 encoder = "SyslogLainEncoder"
 max_buffer_time = 15000
+max_buffered_bytes = 102400
 use_buffering = true
 
 [lain_kafka_output.buffering]
@@ -47,6 +48,7 @@ topic_variable = "Fields[kafka_topic]"
 addrs = {{.KafkaAddrs}}
 encoder = "WebRouterKafkaEncoder"
 max_buffer_time = 15000
+max_buffered_bytes = 102400
 use_buffering = true
 
 [webrouter_kafka_output.buffering]


### PR DESCRIPTION
the origin default value in heka is 1, it's not make sence. the library sarama with the default value will be flushed immediately when every message comes.